### PR TITLE
Renamed options, added option to use different timezone in calendar and twig

### DIFF
--- a/src/Aeon/Symfony/AeonBundle/DependencyInjection/AeonExtension.php
+++ b/src/Aeon/Symfony/AeonBundle/DependencyInjection/AeonExtension.php
@@ -25,10 +25,11 @@ final class AeonExtension extends Extension
         $loader->load('aeon_calendar.php');
         $loader->load('aeon_calendar_twig.php');
 
-        $container->setParameter('aeon.timezone', $config['timezone']);
-        $container->setParameter('aeon.datetime_format', $config['datetime_format']);
-        $container->setParameter('aeon.date_format', $config['date_format']);
-        $container->setParameter('aeon.time_format', $config['time_format']);
+        $container->setParameter('aeon.calendar_timezone', $config['calendar_timezone']);
+        $container->setParameter('aeon.ui_timezone', $config['ui_timezone']);
+        $container->setParameter('aeon.ui_datetime_format', $config['ui_datetime_format']);
+        $container->setParameter('aeon.ui_date_format', $config['ui_date_format']);
+        $container->setParameter('aeon.ui_time_format', $config['ui_time_format']);
 
         if ($container->hasParameter('kernel.environment')) {
             if ($container->getParameter('kernel.environment') === 'test') {

--- a/src/Aeon/Symfony/AeonBundle/DependencyInjection/Configuration.php
+++ b/src/Aeon/Symfony/AeonBundle/DependencyInjection/Configuration.php
@@ -21,10 +21,11 @@ final class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
-                ->scalarNode('timezone')->defaultValue(TimeZone::UTC)->end()
-                ->scalarNode('datetime_format')->defaultValue('Y-m-d H:i:s')->end()
-                ->scalarNode('date_format')->defaultValue('Y-m-d')->end()
-                ->scalarNode('time_format')->defaultValue('H:i:s')->end()
+                ->scalarNode('calendar_timezone')->defaultValue(TimeZone::UTC)->end()
+                ->scalarNode('ui_timezone')->defaultValue(TimeZone::UTC)->end()
+                ->scalarNode('ui_datetime_format')->defaultValue('Y-m-d H:i:s')->end()
+                ->scalarNode('ui_date_format')->defaultValue('Y-m-d')->end()
+                ->scalarNode('ui_time_format')->defaultValue('H:i:s')->end()
             ->end();
 
         return $treeBuilder;

--- a/src/Aeon/Symfony/AeonBundle/Resources/config/aeon_calendar.php
+++ b/src/Aeon/Symfony/AeonBundle/Resources/config/aeon_calendar.php
@@ -11,13 +11,13 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 return static function (ContainerConfigurator $containerConfigurator) : void {
     $services = $containerConfigurator->services();
 
-    $services->set('timezone', TimeZone::class)
-        ->args(['%aeon.timezone%'])
-        ->alias(TimeZone::class, 'timezone')
+    $services->set('calendar_timezone', TimeZone::class)
+        ->args(['%aeon.calendar_timezone%'])
+        ->alias(TimeZone::class, 'calendar_timezone')
         ->public();
 
     $services->set('calendar', GregorianCalendar::class)
-        ->args([ref('timezone')])
+        ->args([ref('calendar_timezone')])
         ->public()
         ->alias(Calendar::class, 'calendar')
         ->public();

--- a/src/Aeon/Symfony/AeonBundle/Resources/config/aeon_calendar_twig.php
+++ b/src/Aeon/Symfony/AeonBundle/Resources/config/aeon_calendar_twig.php
@@ -10,6 +10,6 @@ return static function (ContainerConfigurator $containerConfigurator) : void {
     $services = $containerConfigurator->services();
 
     $services->set('calendar.twig', CalendarExtension::class)
-        ->args([ref('calendar'),  '%aeon.timezone%', '%aeon.datetime_format%', '%aeon.date_format%', '%aeon.time_format%'])
+        ->args([ref('calendar'),  '%aeon.ui_timezone%', '%aeon.ui_datetime_format%', '%aeon.ui_date_format%', '%aeon.ui_time_format%'])
         ->tag('twig.extension', []);
 };

--- a/tests/Aeon/Symfony/AeonBundle/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Aeon/Symfony/AeonBundle/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -14,10 +14,30 @@ final class ConfigurationTest extends TestCase
     {
         $config = $this->process([]);
 
-        $this->assertEquals('UTC', $config['timezone']);
-        $this->assertEquals('Y-m-d H:i:s', $config['datetime_format']);
-        $this->assertEquals('Y-m-d', $config['date_format']);
-        $this->assertEquals('H:i:s', $config['time_format']);
+        $this->assertEquals('UTC', $config['calendar_timezone']);
+        $this->assertEquals('UTC', $config['ui_timezone']);
+        $this->assertEquals('Y-m-d H:i:s', $config['ui_datetime_format']);
+        $this->assertEquals('Y-m-d', $config['ui_date_format']);
+        $this->assertEquals('H:i:s', $config['ui_time_format']);
+    }
+
+    public function test_changed_configuration() : void
+    {
+        $config = $this->process([
+            'aeon' => [
+                'calendar_timezone' => 'UTC',
+                'ui_timezone' => 'America/Los_Angeles',
+                'ui_datetime_format' => 'Y-m-d H i s',
+                'ui_date_format' => 'Y m d',
+                'ui_time_format' => 'H i s',
+            ],
+        ]);
+
+        $this->assertEquals('UTC', $config['calendar_timezone']);
+        $this->assertEquals('America/Los_Angeles', $config['ui_timezone']);
+        $this->assertEquals('Y-m-d H i s', $config['ui_datetime_format']);
+        $this->assertEquals('Y m d', $config['ui_date_format']);
+        $this->assertEquals('H i s', $config['ui_time_format']);
     }
 
     protected function process($configs)


### PR DESCRIPTION
New bundle configuration: 

```yaml
aeon:
  calendar_timezone: 'UTC'
  ui_timezone: 'UTC'
  ui_datetime_format: 'Y-m-d H:i:s'
  ui_date_format: 'Y-m-d'
  ui_time_format: 'H:i:s'
```