### PR TITLE
Added possibilit to validate if given day is not a holiday

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
           - "7.4"
         operating-system:
           - "ubuntu-latest"
-          - "windows-latest"
+          # - "windows-latest" https://twitter.com/norbert_tech/status/1324958486506115073 - feel free to fix
 
     steps:
       - name: "Checkout"

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
     "require": {
         "php": ">=7.4.2",
         "aeon-php/calendar": ">=0.11.0",
+        "aeon-php/calendar-holidays": ">=0.5.0",
         "aeon-php/calendar-twig": ">=0.6.0",
         "aeon-php/retry": ">=0.4.0",
         "aeon-php/sleep": ">=0.5.0",
@@ -18,7 +19,9 @@
         "symfony/validator": "^4.4|^5.0|^5.1"
     },
     "require-dev": {
+        "aeon-php/calendar-holidays-yasumi": ">=0.5.0",
         "phpunit/phpunit": "^9.1",
+        "symfony/browser-kit": "^4.4|^5.0|^5.1",
         "symfony/framework-bundle": "^4.4|^5.0|^5.1"
     },
     "license": "MIT",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6179ce058351d30de55f8c07f2d8c46a",
+    "content-hash": "b5dda6a015543dd8f00257a4c661f40c",
     "packages": [
         {
             "name": "aeon-php/calendar",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dd1f3aa6faa573fd6e668e7565affc61",
+    "content-hash": "6179ce058351d30de55f8c07f2d8c46a",
     "packages": [
         {
             "name": "aeon-php/calendar",
@@ -50,6 +50,10 @@
                 "immutable",
                 "time"
             ],
+            "support": {
+                "issues": "https://github.com/aeon-php/calendar/issues",
+                "source": "https://github.com/aeon-php/calendar/tree/0.11.0"
+            },
             "funding": [
                 {
                     "url": "https://github.com/norberttech",
@@ -57,6 +61,66 @@
                 }
             ],
             "time": "2020-10-23T20:30:34+00:00"
+        },
+        {
+            "name": "aeon-php/calendar-holidays",
+            "version": "0.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/aeon-php/calendar-holidays.git",
+                "reference": "fe57a0be9b517b1539d329e6a89cb303526f93fd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/aeon-php/calendar-holidays/zipball/fe57a0be9b517b1539d329e6a89cb303526f93fd",
+                "reference": "fe57a0be9b517b1539d329e6a89cb303526f93fd",
+                "shasum": ""
+            },
+            "require": {
+                "aeon-php/calendar": ">=0.11.0",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": ">=7.4.2"
+            },
+            "require-dev": {
+                "google/apiclient": "^2.0",
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-latest": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Aeon\\": [
+                        "src/Aeon"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Holidays calendar abstraction layer for Aeon Time management framework",
+            "keywords": [
+                "calendar",
+                "holidays",
+                "immutable",
+                "sleep"
+            ],
+            "support": {
+                "issues": "https://github.com/aeon-php/calendar-holidays/issues",
+                "source": "https://github.com/aeon-php/calendar-holidays/tree/0.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/norberttech",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-05T22:01:09+00:00"
         },
         {
             "name": "aeon-php/calendar-twig",
@@ -104,6 +168,10 @@
                 "immutable",
                 "twig"
             ],
+            "support": {
+                "issues": "https://github.com/aeon-php/calendar-twig/issues",
+                "source": "https://github.com/aeon-php/calendar-twig/tree/0.6.0"
+            },
             "funding": [
                 {
                     "url": "https://github.com/norberttech",
@@ -159,6 +227,10 @@
                 "fail",
                 "retry"
             ],
+            "support": {
+                "issues": "https://github.com/aeon-php/retry/issues",
+                "source": "https://github.com/aeon-php/retry/tree/0.4.0"
+            },
             "funding": [
                 {
                     "url": "https://github.com/norberttech",
@@ -210,6 +282,10 @@
                 "immutable",
                 "sleep"
             ],
+            "support": {
+                "issues": "https://github.com/aeon-php/sleep/issues",
+                "source": "https://github.com/aeon-php/sleep/tree/1.x"
+            },
             "funding": [
                 {
                     "url": "https://github.com/norberttech",
@@ -265,6 +341,10 @@
                 "container-interop",
                 "psr"
             ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/master"
+            },
             "time": "2017-02-14T16:28:37+00:00"
         },
         {
@@ -311,6 +391,10 @@
                 "psr",
                 "psr-14"
             ],
+            "support": {
+                "issues": "https://github.com/php-fig/event-dispatcher/issues",
+                "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
+            },
             "time": "2019-01-08T18:20:26+00:00"
         },
         {
@@ -358,6 +442,9 @@
                 "psr",
                 "psr-3"
             ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/1.1.3"
+            },
             "time": "2020-03-23T09:12:05+00:00"
         },
         {
@@ -419,6 +506,9 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/config/tree/v5.1.8"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -503,6 +593,9 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/dependency-injection/tree/v5.1.8"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -567,6 +660,9 @@
             ],
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/master"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -633,6 +729,9 @@
             ],
             "description": "Symfony ErrorHandler Component",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/error-handler/tree/v5.1.8"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -715,6 +814,9 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/event-dispatcher/tree/v5.1.8"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -791,6 +893,9 @@
                 "interoperability",
                 "standards"
             ],
+            "support": {
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v2.2.0"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -850,6 +955,9 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v5.1.8"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -948,6 +1056,9 @@
             ],
             "description": "Symfony Form Component",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/form/tree/v5.1.8"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -1024,6 +1135,9 @@
                 "interoperability",
                 "standards"
             ],
+            "support": {
+                "source": "https://github.com/symfony/http-client-contracts/tree/v2.3.1"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -1094,6 +1208,9 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/http-foundation/tree/v5.1.8"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -1203,6 +1320,9 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/http-kernel/tree/v5.1.8"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -1288,6 +1408,9 @@
                 "l10n",
                 "localization"
             ],
+            "support": {
+                "source": "https://github.com/symfony/intl/tree/v5.1.8"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -1353,6 +1476,9 @@
                 "configuration",
                 "options"
             ],
+            "support": {
+                "source": "https://github.com/symfony/options-resolver/tree/v5.1.8"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -1429,6 +1555,9 @@
                 "polyfill",
                 "portable"
             ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.20.0"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -1507,6 +1636,9 @@
                 "portable",
                 "shim"
             ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.20.0"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -1583,6 +1715,9 @@
                 "portable",
                 "shim"
             ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-icu/tree/v1.20.0"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -1664,6 +1799,9 @@
                 "portable",
                 "shim"
             ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.20.0"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -1741,6 +1879,9 @@
                 "portable",
                 "shim"
             ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.20.0"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -1817,6 +1958,9 @@
                 "portable",
                 "shim"
             ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.20.0"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -1897,6 +2041,9 @@
                 "portable",
                 "shim"
             ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.20.0"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -1974,6 +2121,9 @@
                 "property path",
                 "reflection"
             ],
+            "support": {
+                "source": "https://github.com/symfony/property-access/tree/v5.1.8"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -2060,6 +2210,9 @@
                 "type",
                 "validator"
             ],
+            "support": {
+                "source": "https://github.com/symfony/property-info/tree/v5.1.8"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -2136,6 +2289,9 @@
                 "interoperability",
                 "standards"
             ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/master"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -2216,6 +2372,9 @@
                 "utf-8",
                 "utf8"
             ],
+            "support": {
+                "source": "https://github.com/symfony/string/tree/v5.1.8"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -2291,6 +2450,9 @@
                 "interoperability",
                 "standards"
             ],
+            "support": {
+                "source": "https://github.com/symfony/translation-contracts/tree/v2.3.0"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -2396,6 +2558,9 @@
             ],
             "description": "Symfony Validator Component",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/validator/tree/v5.1.8"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -2481,6 +2646,9 @@
                 "debug",
                 "dump"
             ],
+            "support": {
+                "source": "https://github.com/symfony/var-dumper/tree/v5.1.8"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -2499,16 +2667,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v3.1.0",
+            "version": "v3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "9a29e1fa7b5431969f96878b8662e3fcb18601b7"
+                "reference": "b02fa41f3783a2616eccef7b92fbc2343ffed737"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/9a29e1fa7b5431969f96878b8662e3fcb18601b7",
-                "reference": "9a29e1fa7b5431969f96878b8662e3fcb18601b7",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/b02fa41f3783a2616eccef7b92fbc2343ffed737",
+                "reference": "b02fa41f3783a2616eccef7b92fbc2343ffed737",
                 "shasum": ""
             },
             "require": {
@@ -2557,6 +2725,10 @@
             "keywords": [
                 "templating"
             ],
+            "support": {
+                "issues": "https://github.com/twigphp/Twig/issues",
+                "source": "https://github.com/twigphp/Twig/tree/v3.1.1"
+            },
             "funding": [
                 {
                     "url": "https://github.com/fabpot",
@@ -2567,10 +2739,134 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-21T12:45:34+00:00"
+            "time": "2020-10-27T19:28:23+00:00"
         }
     ],
     "packages-dev": [
+        {
+            "name": "aeon-php/calendar-holidays-yasumi",
+            "version": "0.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/aeon-php/calendar-holidays-yasumi.git",
+                "reference": "ff5ada9b198bad49d1ba792a9ae68b04a4a9fe30"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/aeon-php/calendar-holidays-yasumi/zipball/ff5ada9b198bad49d1ba792a9ae68b04a4a9fe30",
+                "reference": "ff5ada9b198bad49d1ba792a9ae68b04a4a9fe30",
+                "shasum": ""
+            },
+            "require": {
+                "aeon-php/calendar-holidays": ">=0.5.0",
+                "azuyalabs/yasumi": "^2.0",
+                "php": ">=7.4.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Aeon\\": [
+                        "src/Aeon"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Bridge for Aeon Calendar Holidays library and Yasumi",
+            "keywords": [
+                "Bridge",
+                "Yasumi",
+                "calendar",
+                "holidays",
+                "immutable"
+            ],
+            "support": {
+                "issues": "https://github.com/aeon-php/calendar-holidays-yasumi/issues",
+                "source": "https://github.com/aeon-php/calendar-holidays-yasumi/tree/0.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/norberttech",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-06T18:59:28+00:00"
+        },
+        {
+            "name": "azuyalabs/yasumi",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/azuyalabs/yasumi.git",
+                "reference": "e2f37e6de3b15642b83275a24bbfe101cd5c7791"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/azuyalabs/yasumi/zipball/e2f37e6de3b15642b83275a24bbfe101cd5c7791",
+                "reference": "e2f37e6de3b15642b83275a24bbfe101cd5c7791",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.16",
+                "fzaninotto/faker": "^1.9",
+                "mikey179/vfsstream": "^1.6",
+                "phpunit/phpunit": "^8.5"
+            },
+            "suggest": {
+                "ext-calendar": "For calculating the date of Easter"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Yasumi\\": "src/Yasumi/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sacha Telgenhof",
+                    "email": "me@sachatelgenhof.com",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "The easy PHP Library for calculating holidays.",
+            "homepage": "https://www.yasumi.dev",
+            "keywords": [
+                "Bank",
+                "calculation",
+                "calendar",
+                "celebration",
+                "date",
+                "holiday",
+                "holidays",
+                "national",
+                "time"
+            ],
+            "support": {
+                "docs": "https://www.yasumi.dev",
+                "issues": "https://github.com/azuyalabs/yasumi/issues",
+                "source": "https://github.com/azuyalabs/yasumi"
+            },
+            "funding": [
+                {
+                    "url": "https://www.buymeacoffee.com/sachatelgenhof",
+                    "type": "other"
+                }
+            ],
+            "time": "2020-06-22T12:46:20+00:00"
+        },
         {
             "name": "doctrine/instantiator",
             "version": "1.3.1",
@@ -2625,6 +2921,10 @@
                 "constructor",
                 "instantiate"
             ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/1.3.x"
+            },
             "funding": [
                 {
                     "url": "https://www.doctrine-project.org/sponsorship.html",
@@ -2687,6 +2987,10 @@
                 "object",
                 "object graph"
             ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.x"
+            },
             "funding": [
                 {
                     "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
@@ -2745,6 +3049,10 @@
                 "parser",
                 "php"
             ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.10.2"
+            },
             "time": "2020-09-26T10:30:38+00:00"
         },
         {
@@ -2801,6 +3109,10 @@
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/master"
+            },
             "time": "2020-06-27T14:33:11+00:00"
         },
         {
@@ -2848,6 +3160,10 @@
                 }
             ],
             "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/master"
+            },
             "time": "2020-06-27T14:39:04+00:00"
         },
         {
@@ -2897,6 +3213,10 @@
                 "reflection",
                 "static analysis"
             ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
+            },
             "time": "2020-06-27T09:03:43+00:00"
         },
         {
@@ -2949,6 +3269,10 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/master"
+            },
             "time": "2020-09-03T19:13:55+00:00"
         },
         {
@@ -2994,6 +3318,10 @@
                 }
             ],
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.4.0"
+            },
             "time": "2020-09-17T18:55:26+00:00"
         },
         {
@@ -3057,27 +3385,31 @@
                 "spy",
                 "stub"
             ],
+            "support": {
+                "issues": "https://github.com/phpspec/prophecy/issues",
+                "source": "https://github.com/phpspec/prophecy/tree/1.12.1"
+            },
             "time": "2020-09-29T09:10:42+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.0",
+            "version": "9.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "53a4b737e83be724efd2bc4e7b929b9a30c48972"
+                "reference": "6b20e2055f7c29b56cb3870b3de7cc463d7add41"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/53a4b737e83be724efd2bc4e7b929b9a30c48972",
-                "reference": "53a4b737e83be724efd2bc4e7b929b9a30c48972",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/6b20e2055f7c29b56cb3870b3de7cc463d7add41",
+                "reference": "6b20e2055f7c29b56cb3870b3de7cc463d7add41",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.8",
+                "nikic/php-parser": "^4.10.2",
                 "php": ">=7.3",
                 "phpunit/php-file-iterator": "^3.0.3",
                 "phpunit/php-text-template": "^2.0.2",
@@ -3124,13 +3456,17 @@
                 "testing",
                 "xunit"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.3"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-10-02T03:37:32+00:00"
+            "time": "2020-10-30T10:46:41+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -3180,6 +3516,10 @@
                 "filesystem",
                 "iterator"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.5"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -3239,6 +3579,10 @@
             "keywords": [
                 "process"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -3249,16 +3593,16 @@
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "2.0.3",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "18c887016e60e52477e54534956d7b47bc52cd84"
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/18c887016e60e52477e54534956d7b47bc52cd84",
-                "reference": "18c887016e60e52477e54534956d7b47bc52cd84",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
                 "shasum": ""
             },
             "require": {
@@ -3294,26 +3638,30 @@
             "keywords": [
                 "template"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:03:05+00:00"
+            "time": "2020-10-26T05:33:50+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "5.0.2",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "c9ff14f493699e2f6adee9fd06a0245b276643b7"
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/c9ff14f493699e2f6adee9fd06a0245b276643b7",
-                "reference": "c9ff14f493699e2f6adee9fd06a0245b276643b7",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
                 "shasum": ""
             },
             "require": {
@@ -3349,13 +3697,17 @@
             "keywords": [
                 "timer"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:00:25+00:00"
+            "time": "2020-10-26T13:16:10+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -3444,6 +3796,10 @@
                 "testing",
                 "xunit"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.4.2"
+            },
             "funding": [
                 {
                     "url": "https://phpunit.de/donate.html",
@@ -3500,6 +3856,9 @@
                 "psr",
                 "psr-6"
             ],
+            "support": {
+                "source": "https://github.com/php-fig/cache/tree/master"
+            },
             "time": "2016-08-06T20:24:11+00:00"
         },
         {
@@ -3546,6 +3905,10 @@
             ],
             "description": "Library for parsing CLI options",
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -3556,16 +3919,16 @@
         },
         {
             "name": "sebastian/code-unit",
-            "version": "1.0.7",
+            "version": "1.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "59236be62b1bb9919e6d7f60b0b832dc05cef9ab"
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/59236be62b1bb9919e6d7f60b0b832dc05cef9ab",
-                "reference": "59236be62b1bb9919e6d7f60b0b832dc05cef9ab",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
                 "shasum": ""
             },
             "require": {
@@ -3598,13 +3961,17 @@
             ],
             "description": "Collection of value objects that represent the PHP code units",
             "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-10-02T14:47:54+00:00"
+            "time": "2020-10-26T13:08:54+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -3649,6 +4016,10 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -3659,16 +4030,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.5",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "7a8ff306445707539c1a6397372a982a1ec55120"
+                "reference": "55f4261989e546dc112258c7a75935a81a7ce382"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/7a8ff306445707539c1a6397372a982a1ec55120",
-                "reference": "7a8ff306445707539c1a6397372a982a1ec55120",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/55f4261989e546dc112258c7a75935a81a7ce382",
+                "reference": "55f4261989e546dc112258c7a75935a81a7ce382",
                 "shasum": ""
             },
             "require": {
@@ -3719,26 +4090,30 @@
                 "compare",
                 "equality"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.6"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-09-30T06:47:25+00:00"
+            "time": "2020-10-26T15:49:45+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "ba8cc2da0c0bfbc813d03b56406734030c7f1eff"
+                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/ba8cc2da0c0bfbc813d03b56406734030c7f1eff",
-                "reference": "ba8cc2da0c0bfbc813d03b56406734030c7f1eff",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
+                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
                 "shasum": ""
             },
             "require": {
@@ -3772,26 +4147,30 @@
             ],
             "description": "Library for calculating the complexity of PHP code units",
             "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:05:03+00:00"
+            "time": "2020-10-26T15:52:27+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.3",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "ffc949a1a2aae270ea064453d7535b82e4c32092"
+                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ffc949a1a2aae270ea064453d7535b82e4c32092",
-                "reference": "ffc949a1a2aae270ea064453d7535b82e4c32092",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
                 "shasum": ""
             },
             "require": {
@@ -3834,13 +4213,17 @@
                 "unidiff",
                 "unified diff"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:32:55+00:00"
+            "time": "2020-10-26T13:10:38+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -3893,6 +4276,10 @@
                 "environment",
                 "hhvm"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.3"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -3966,6 +4353,10 @@
                 "export",
                 "exporter"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.3"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -3976,16 +4367,16 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.1",
+            "version": "5.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "ea779cb749a478b22a2564ac41cd7bda79c78dc7"
+                "reference": "a90ccbddffa067b51f574dea6eb25d5680839455"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/ea779cb749a478b22a2564ac41cd7bda79c78dc7",
-                "reference": "ea779cb749a478b22a2564ac41cd7bda79c78dc7",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/a90ccbddffa067b51f574dea6eb25d5680839455",
+                "reference": "a90ccbddffa067b51f574dea6eb25d5680839455",
                 "shasum": ""
             },
             "require": {
@@ -4026,26 +4417,30 @@
             "keywords": [
                 "global state"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.2"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:54:06+00:00"
+            "time": "2020-10-26T15:55:19+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "6514b8f21906b8b46f520d1fbd17a4523fa59a54"
+                "reference": "acf76492a65401babcf5283296fa510782783a7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/6514b8f21906b8b46f520d1fbd17a4523fa59a54",
-                "reference": "6514b8f21906b8b46f520d1fbd17a4523fa59a54",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/acf76492a65401babcf5283296fa510782783a7a",
+                "reference": "acf76492a65401babcf5283296fa510782783a7a",
                 "shasum": ""
             },
             "require": {
@@ -4079,26 +4474,30 @@
             ],
             "description": "Library for counting the lines of code in PHP source code",
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.2"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:07:27+00:00"
+            "time": "2020-10-26T17:03:56+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "4.0.3",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "f6f5957013d84725427d361507e13513702888a4"
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/f6f5957013d84725427d361507e13513702888a4",
-                "reference": "f6f5957013d84725427d361507e13513702888a4",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
                 "shasum": ""
             },
             "require": {
@@ -4132,26 +4531,30 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:55:06+00:00"
+            "time": "2020-10-26T13:12:34+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "2.0.3",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "d9d0ab3b12acb1768bc1e0a89b23c90d2043cbe5"
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/d9d0ab3b12acb1768bc1e0a89b23c90d2043cbe5",
-                "reference": "d9d0ab3b12acb1768bc1e0a89b23c90d2043cbe5",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
                 "shasum": ""
             },
             "require": {
@@ -4183,26 +4586,30 @@
             ],
             "description": "Allows reflection of object attributes, including inherited and non-public ones",
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:56:16+00:00"
+            "time": "2020-10-26T13:14:26+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.3",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "ed8c9cd355089134bc9cba421b5cfdd58f0eaef7"
+                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/ed8c9cd355089134bc9cba421b5cfdd58f0eaef7",
-                "reference": "ed8c9cd355089134bc9cba421b5cfdd58f0eaef7",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/cd9d8cf3c5804de4341c283ed787f099f5506172",
+                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172",
                 "shasum": ""
             },
             "require": {
@@ -4242,13 +4649,17 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.4"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:17:32+00:00"
+            "time": "2020-10-26T13:17:30+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -4293,6 +4704,10 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -4303,16 +4718,16 @@
         },
         {
             "name": "sebastian/type",
-            "version": "2.3.0",
+            "version": "2.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "fa592377f3923946cb90bf1f6a71ba2e5f229909"
+                "reference": "81cd61ab7bbf2de744aba0ea61fae32f721df3d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/fa592377f3923946cb90bf1f6a71ba2e5f229909",
-                "reference": "fa592377f3923946cb90bf1f6a71ba2e5f229909",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/81cd61ab7bbf2de744aba0ea61fae32f721df3d2",
+                "reference": "81cd61ab7bbf2de744aba0ea61fae32f721df3d2",
                 "shasum": ""
             },
             "require": {
@@ -4345,13 +4760,17 @@
             ],
             "description": "Collection of value objects that represent the types of the PHP type system",
             "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/2.3.1"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-10-06T08:41:03+00:00"
+            "time": "2020-10-26T13:18:59+00:00"
         },
         {
             "name": "sebastian/version",
@@ -4394,6 +4813,10 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -4401,6 +4824,77 @@
                 }
             ],
             "time": "2020-09-28T06:39:44+00:00"
+        },
+        {
+            "name": "symfony/browser-kit",
+            "version": "v5.1.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/browser-kit.git",
+                "reference": "65b7d208280f2700f43ba44a8059a25d7b01347b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/65b7d208280f2700f43ba44a8059a25d7b01347b",
+                "reference": "65b7d208280f2700f43ba44a8059a25d7b01347b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/dom-crawler": "^4.4|^5.0"
+            },
+            "require-dev": {
+                "symfony/css-selector": "^4.4|^5.0",
+                "symfony/http-client": "^4.4|^5.0",
+                "symfony/mime": "^4.4|^5.0",
+                "symfony/process": "^4.4|^5.0"
+            },
+            "suggest": {
+                "symfony/process": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\BrowserKit\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony BrowserKit Component",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/browser-kit/tree/v5.1.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-24T12:01:57+00:00"
         },
         {
             "name": "symfony/cache",
@@ -4476,6 +4970,9 @@
                 "caching",
                 "psr6"
             ],
+            "support": {
+                "source": "https://github.com/symfony/cache/tree/v5.1.8"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -4552,6 +5049,9 @@
                 "interoperability",
                 "standards"
             ],
+            "support": {
+                "source": "https://github.com/symfony/cache-contracts/tree/v2.2.0"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -4567,6 +5067,80 @@
                 }
             ],
             "time": "2020-09-07T11:33:47+00:00"
+        },
+        {
+            "name": "symfony/dom-crawler",
+            "version": "v5.1.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/dom-crawler.git",
+                "reference": "0969122fe144dd8ab2e8c98c7e03eedc621b368c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/0969122fe144dd8ab2e8c98c7e03eedc621b368c",
+                "reference": "0969122fe144dd8ab2e8c98c7e03eedc621b368c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php80": "^1.15"
+            },
+            "conflict": {
+                "masterminds/html5": "<2.6"
+            },
+            "require-dev": {
+                "masterminds/html5": "^2.6",
+                "symfony/css-selector": "^4.4|^5.0"
+            },
+            "suggest": {
+                "symfony/css-selector": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\DomCrawler\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony DomCrawler Component",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/dom-crawler/tree/v5.1.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-24T12:01:57+00:00"
         },
         {
             "name": "symfony/finder",
@@ -4610,6 +5184,9 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/finder/tree/v5.1.8"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -4752,6 +5329,9 @@
             ],
             "description": "Symfony FrameworkBundle",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/framework-bundle/tree/v5.1.8"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -4839,6 +5419,9 @@
                 "uri",
                 "url"
             ],
+            "support": {
+                "source": "https://github.com/symfony/routing/tree/v5.1.8"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -4909,6 +5492,9 @@
                 "instantiate",
                 "serialize"
             ],
+            "support": {
+                "source": "https://github.com/symfony/var-exporter/tree/v5.1.8"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -4963,6 +5549,10 @@
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/master"
+            },
             "funding": [
                 {
                     "url": "https://github.com/theseer",
@@ -5018,6 +5608,10 @@
                 "check",
                 "validate"
             ],
+            "support": {
+                "issues": "https://github.com/webmozart/assert/issues",
+                "source": "https://github.com/webmozart/assert/tree/master"
+            },
             "time": "2020-07-08T17:02:28+00:00"
         }
     ],
@@ -5030,5 +5624,5 @@
         "php": ">=7.4.2"
     },
     "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,6 +6,12 @@
          bootstrap="vendor/autoload.php"
          cacheResultFile="var/phpunit/.result.cache"
 >
+    <php>
+        <ini name="error_reporting" value="-1" />
+        <server name="APP_ENV" value="test" force="true" />
+        <server name="SHELL_VERBOSITY" value="-1" />
+    </php>
+
     <logging>
         <log type="coverage-html" target="var/phpunit/coverage/html" lowUpperBound="95" highLowerBound="100"/>
     </logging>

--- a/src/Aeon/Symfony/AeonBundle/DependencyInjection/AeonExtension.php
+++ b/src/Aeon/Symfony/AeonBundle/DependencyInjection/AeonExtension.php
@@ -24,12 +24,19 @@ final class AeonExtension extends Extension
         $loader = new PhpFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('aeon_calendar.php');
         $loader->load('aeon_calendar_twig.php');
+        $loader->load('aeon_calendar_holidays_google.php');
+        $loader->load('aeon_calendar_holidays_yasumi.php');
+        $loader->load('aeon_calendar_holidays.php');
 
         $container->setParameter('aeon.calendar_timezone', $config['calendar_timezone']);
         $container->setParameter('aeon.ui_timezone', $config['ui_timezone']);
         $container->setParameter('aeon.ui_datetime_format', $config['ui_datetime_format']);
         $container->setParameter('aeon.ui_date_format', $config['ui_date_format']);
         $container->setParameter('aeon.ui_time_format', $config['ui_time_format']);
+
+        if ($container->has((string) $config['calendar_holidays_factory_service'])) {
+            $container->setAlias('aeon.calendar.holidays.factory', (string) $config['calendar_holidays_factory_service']);
+        }
 
         if ($container->hasParameter('kernel.environment')) {
             if ($container->getParameter('kernel.environment') === 'test') {

--- a/src/Aeon/Symfony/AeonBundle/DependencyInjection/Configuration.php
+++ b/src/Aeon/Symfony/AeonBundle/DependencyInjection/Configuration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Aeon\Symfony\AeonBundle\DependencyInjection;
 
+use Aeon\Calendar\Gregorian\Holidays\GoogleRegionalHolidaysFactory;
 use Aeon\Calendar\Gregorian\TimeZone;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -22,6 +23,7 @@ final class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->scalarNode('calendar_timezone')->defaultValue(TimeZone::UTC)->end()
+                ->scalarNode('calendar_holidays_factory_service')->defaultValue(GoogleRegionalHolidaysFactory::class)->end()
                 ->scalarNode('ui_timezone')->defaultValue(TimeZone::UTC)->end()
                 ->scalarNode('ui_datetime_format')->defaultValue('Y-m-d H:i:s')->end()
                 ->scalarNode('ui_date_format')->defaultValue('Y-m-d')->end()

--- a/src/Aeon/Symfony/AeonBundle/Form/DataTransformer/AeonDayToDateTimeTransformer.php
+++ b/src/Aeon/Symfony/AeonBundle/Form/DataTransformer/AeonDayToDateTimeTransformer.php
@@ -15,7 +15,7 @@ final class AeonDayToDateTimeTransformer implements DataTransformerInterface
      */
     public function transform($value)
     {
-        if ($value instanceof DAy) {
+        if ($value instanceof Day) {
             return $value->toDateTimeImmutable();
         }
 

--- a/src/Aeon/Symfony/AeonBundle/Resources/config/aeon_calendar_holidays.php
+++ b/src/Aeon/Symfony/AeonBundle/Resources/config/aeon_calendar_holidays.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\ref;
+use Aeon\Symfony\AeonBundle\Validator\Constraints\NotHolidayValidator;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator) : void {
+    $services = $containerConfigurator->services();
+
+    $services->set('calendar.holidays.validator.not_holiday', NotHolidayValidator::class)
+        ->args([ref('aeon.calendar.holidays.factory')])
+        ->tag('validator.constraint_validator', ['alias' => 'calendar.holidays.validator.not_holiday'])
+        ->alias(NotHolidayValidator::class, 'calendar.holidays.validator.not_holiday');
+};

--- a/src/Aeon/Symfony/AeonBundle/Resources/config/aeon_calendar_holidays.php
+++ b/src/Aeon/Symfony/AeonBundle/Resources/config/aeon_calendar_holidays.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use function Symfony\Component\DependencyInjection\Loader\Configurator\ref;
+use Aeon\Symfony\AeonBundle\Validator\Constraints\HolidayValidator;
 use Aeon\Symfony\AeonBundle\Validator\Constraints\NotHolidayValidator;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
@@ -13,4 +14,9 @@ return static function (ContainerConfigurator $containerConfigurator) : void {
         ->args([ref('aeon.calendar.holidays.factory')])
         ->tag('validator.constraint_validator', ['alias' => 'calendar.holidays.validator.not_holiday'])
         ->alias(NotHolidayValidator::class, 'calendar.holidays.validator.not_holiday');
+
+    $services->set('calendar.holidays.validator.holiday', HolidayValidator::class)
+        ->args([ref('aeon.calendar.holidays.factory')])
+        ->tag('validator.constraint_validator', ['alias' => 'calendar.holidays.validator.holiday'])
+        ->alias(HolidayValidator::class, 'calendar.holidays.validator.holiday');
 };

--- a/src/Aeon/Symfony/AeonBundle/Resources/config/aeon_calendar_holidays_google.php
+++ b/src/Aeon/Symfony/AeonBundle/Resources/config/aeon_calendar_holidays_google.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Aeon\Calendar\Gregorian\Holidays\GoogleRegionalHolidaysFactory;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator) : void {
+    $services = $containerConfigurator->services();
+
+    $services->set('calendar.holidays.factory.google', GoogleRegionalHolidaysFactory::class)
+        ->alias(GoogleRegionalHolidaysFactory::class, 'calendar.holidays.factory.google');
+};

--- a/src/Aeon/Symfony/AeonBundle/Resources/config/aeon_calendar_holidays_yasumi.php
+++ b/src/Aeon/Symfony/AeonBundle/Resources/config/aeon_calendar_holidays_yasumi.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator) : void {
+    $services = $containerConfigurator->services();
+
+    if (\class_exists('Aeon\Calendar\Gregorian\YasumiHolidaysFactory')) {
+        $services->set('calendar.holidays.factory.yasumi', 'Aeon\Calendar\Gregorian\YasumiHolidaysFactory');
+    }
+};

--- a/src/Aeon/Symfony/AeonBundle/Validator/Constraints/Holiday.php
+++ b/src/Aeon/Symfony/AeonBundle/Validator/Constraints/Holiday.php
@@ -6,15 +6,15 @@ namespace Aeon\Symfony\AeonBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
-final class NotHoliday extends Constraint
+final class Holiday extends Constraint
 {
-    public const HOLIDAY_DAY = 'a4a2fb95-c359-4683-8fbc-307967dd28a4';
+    public const NOT_HOLIDAY_DAY = 'a4a2fb95-c359-4683-8fbc-307967dd28a4';
 
     protected static $errorNames = [
-        self::HOLIDAY_DAY => 'HOLIDAY_DAY',
+        self::NOT_HOLIDAY_DAY => 'NOT_HOLIDAY_DAY',
     ];
 
-    public $message = 'Day {{ day }} is a holiday.';
+    public $message = 'Day {{ day }} is not a holiday.';
 
     public $countryCode;
 
@@ -30,6 +30,6 @@ final class NotHoliday extends Constraint
 
     public function validatedBy()
     {
-        return 'calendar.holidays.validator.not_holiday';
+        return 'calendar.holidays.validator.holiday';
     }
 }

--- a/src/Aeon/Symfony/AeonBundle/Validator/Constraints/HolidayValidator.php
+++ b/src/Aeon/Symfony/AeonBundle/Validator/Constraints/HolidayValidator.php
@@ -11,7 +11,7 @@ use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 use Symfony\Component\Validator\Exception\UnexpectedValueException;
 
-final class NotHolidayValidator extends ConstraintValidator
+final class HolidayValidator extends ConstraintValidator
 {
     private HolidaysFactory $factory;
 
@@ -25,8 +25,8 @@ final class NotHolidayValidator extends ConstraintValidator
      */
     public function validate($value, Constraint $constraint) : void
     {
-        if (!$constraint instanceof NotHoliday) {
-            throw new UnexpectedTypeException($constraint, NotHoliday::class);
+        if (!$constraint instanceof Holiday) {
+            throw new UnexpectedTypeException($constraint, Holiday::class);
         }
 
         if (null === $value || '' === $value) {
@@ -50,20 +50,20 @@ final class NotHolidayValidator extends ConstraintValidator
 
             $holidays = $this->factory->create($constraint->countryCode);
 
-            if (!$holidays->isHoliday($day)) {
+            if ($holidays->isHoliday($day)) {
                 return;
             }
 
             $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ day }}', $this->formatValue($day->toString()))
-                ->setCode(NotHoliday::HOLIDAY_DAY)
+                ->setCode(Holiday::NOT_HOLIDAY_DAY)
                 ->addViolation();
 
             return;
         } catch (\Exception $exception) {
             $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ day }}', $this->formatValue($value))
-                ->setCode(NotHoliday::HOLIDAY_DAY)
+                ->setCode(Holiday::NOT_HOLIDAY_DAY)
                 ->addViolation();
 
             return;

--- a/src/Aeon/Symfony/AeonBundle/Validator/Constraints/NotHoliday.php
+++ b/src/Aeon/Symfony/AeonBundle/Validator/Constraints/NotHoliday.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aeon\Symfony\AeonBundle\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+final class NotHoliday extends Constraint
+{
+    public const NOT_HOLIDAY_DAY = 'a4a2fb95-c359-4683-8fbc-307967dd28a4';
+
+    protected static $errorNames = [
+        self::NOT_HOLIDAY_DAY => 'NOT_HOLIDAY_DAY',
+    ];
+
+    public $message = 'Day {{ day }} is a holiday.';
+
+    public $countryCode;
+
+    public function __construct($options = null)
+    {
+        parent::__construct($options);
+    }
+
+    public function getRequiredOptions()
+    {
+        return ['countryCode'];
+    }
+
+    public function validatedBy()
+    {
+        return 'calendar.holidays.validator.not_holiday';
+    }
+}

--- a/src/Aeon/Symfony/AeonBundle/Validator/Constraints/NotHolidayValidator.php
+++ b/src/Aeon/Symfony/AeonBundle/Validator/Constraints/NotHolidayValidator.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aeon\Symfony\AeonBundle\Validator\Constraints;
+
+use Aeon\Calendar\Gregorian\Day;
+use Aeon\Calendar\Gregorian\HolidaysFactory;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+
+final class NotHolidayValidator extends ConstraintValidator
+{
+    private HolidaysFactory $factory;
+
+    public function __construct(HolidaysFactory $factory)
+    {
+        $this->factory = $factory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($value, Constraint $constraint) : void
+    {
+        if (!$constraint instanceof NotHoliday) {
+            throw new UnexpectedTypeException($constraint, NotHoliday::class);
+        }
+
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        if (!\is_string($value) && !$value instanceof Day && !$value instanceof \DateTimeInterface) {
+            \var_dump($value);
+
+            throw new UnexpectedValueException($value, 'string or ' . Day::class);
+        }
+
+        try {
+            if (\is_string($value)) {
+                $day = Day::fromString($value);
+            } elseif ($value instanceof \DateTimeInterface) {
+                $day = Day::fromDateTime($value);
+            } else {
+                $day = $value;
+            }
+
+            $holidays = $this->factory->create($constraint->countryCode);
+
+            if (!$holidays->isHoliday($day)) {
+                return;
+            }
+
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ day }}', $this->formatValue($day->toString()))
+                ->setCode(NotHoliday::NOT_HOLIDAY_DAY)
+                ->addViolation();
+
+            return;
+        } catch (\Exception $exception) {
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ day }}', $this->formatValue($value))
+                ->setCode(NotHoliday::NOT_HOLIDAY_DAY)
+                ->addViolation();
+
+            return;
+        }
+    }
+}

--- a/tests/Aeon/Symfony/AeonBundle/Tests/Functional/App/Form/NotHolidaysFormType.php
+++ b/tests/Aeon/Symfony/AeonBundle/Tests/Functional/App/Form/NotHolidaysFormType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Aeon\Symfony\AeonBundle\Tests\Functional\App\Form;
 
 use Aeon\Symfony\AeonBundle\Form\Type\AeonDayType;
+use Aeon\Symfony\AeonBundle\Validator\Constraints\Holiday;
 use Aeon\Symfony\AeonBundle\Validator\Constraints\NotHoliday;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -16,10 +17,16 @@ final class NotHolidaysFormType extends AbstractType
     {
         $builder->setMethod('POST');
 
-        $builder->add('day', AeonDayType::class, [
+        $builder->add('not_holiday', AeonDayType::class, [
             'widget' => 'single_text',
             'input' => 'string',
             'constraints' => [new NotHoliday(['countryCode' => 'US'])],
+        ]);
+
+        $builder->add('holiday', AeonDayType::class, [
+            'widget' => 'single_text',
+            'input' => 'string',
+            'constraints' => [new Holiday(['countryCode' => 'US'])],
         ]);
     }
 
@@ -32,6 +39,6 @@ final class NotHolidaysFormType extends AbstractType
 
     public function getBlockPrefix()
     {
-        return 'not_holidays';
+        return 'holidays';
     }
 }

--- a/tests/Aeon/Symfony/AeonBundle/Tests/Functional/App/Form/NotHolidaysFormType.php
+++ b/tests/Aeon/Symfony/AeonBundle/Tests/Functional/App/Form/NotHolidaysFormType.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aeon\Symfony\AeonBundle\Tests\Functional\App\Form;
+
+use Aeon\Symfony\AeonBundle\Form\Type\AeonDayType;
+use Aeon\Symfony\AeonBundle\Validator\Constraints\NotHoliday;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class NotHolidaysFormType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options) : void
+    {
+        $builder->setMethod('POST');
+
+        $builder->add('day', AeonDayType::class, [
+            'widget' => 'single_text',
+            'input' => 'string',
+            'constraints' => [new NotHoliday(['countryCode' => 'US'])],
+        ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver) : void
+    {
+        $resolver->setDefaults([
+            'csrf_protection' => false,
+        ]);
+    }
+
+    public function getBlockPrefix()
+    {
+        return 'not_holidays';
+    }
+}

--- a/tests/Aeon/Symfony/AeonBundle/Tests/Functional/App/TestAppKernel.php
+++ b/tests/Aeon/Symfony/AeonBundle/Tests/Functional/App/TestAppKernel.php
@@ -63,6 +63,6 @@ final class TestAppKernel extends BaseKernel
 
     protected function configureRoutes(RouteCollectionBuilder $routes) : void
     {
-        $routes->add('not_holiday', '/not-holiday')->controller([$this, 'notHoliday']);
+        $routes->add('/not-holiday', 'kernel::notHoliday');
     }
 }

--- a/tests/Aeon/Symfony/AeonBundle/Tests/Functional/App/TestAppKernel.php
+++ b/tests/Aeon/Symfony/AeonBundle/Tests/Functional/App/TestAppKernel.php
@@ -37,14 +37,14 @@ final class TestAppKernel extends BaseKernel
         return \sys_get_temp_dir() . '/AeonBundle/logs';
     }
 
-    public function notHoliday(Request $request) : Response
+    public function holiday(Request $request) : Response
     {
         $form = $this->getContainer()->get('form.factory')->create(NotHolidaysFormType::class);
 
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            return new Response('not-holiday');
+            return new Response();
         }
 
         return new Response((string) $form->getErrors(true, false), 422);
@@ -63,6 +63,6 @@ final class TestAppKernel extends BaseKernel
 
     protected function configureRoutes(RouteCollectionBuilder $routes) : void
     {
-        $routes->add('/not-holiday', 'kernel::notHoliday');
+        $routes->add('/holiday', 'kernel::holiday');
     }
 }

--- a/tests/Aeon/Symfony/AeonBundle/Tests/Functional/App/TestAppKernel.php
+++ b/tests/Aeon/Symfony/AeonBundle/Tests/Functional/App/TestAppKernel.php
@@ -13,7 +13,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
-use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+use Symfony\Component\Routing\RouteCollectionBuilder;
 
 final class TestAppKernel extends BaseKernel
 {
@@ -61,7 +61,7 @@ final class TestAppKernel extends BaseKernel
         ]);
     }
 
-    protected function configureRoutes(RoutingConfigurator $routes) : void
+    protected function configureRoutes(RouteCollectionBuilder $routes) : void
     {
         $routes->add('not_holiday', '/not-holiday')->controller([$this, 'notHoliday']);
     }

--- a/tests/Aeon/Symfony/AeonBundle/Tests/Functional/FormTest.php
+++ b/tests/Aeon/Symfony/AeonBundle/Tests/Functional/FormTest.php
@@ -13,7 +13,7 @@ final class FormTest extends WebTestCase
     {
         $client = self::createClient();
 
-        $client->request('POST', '/not-holiday', ['not_holidays' => ['day' => '2020-01-01']]);
+        $client->request('POST', '/holiday', ['holidays' => ['not_holiday' => '2020-01-01', 'holiday' => '2020-01-01']]);
 
         $this->assertSame(422, $client->getResponse()->getStatusCode(), $client->getResponse()->getContent());
         $this->assertStringContainsString('ERROR: Day "2020-01-01" is a holiday.', $client->getResponse()->getContent());
@@ -23,10 +23,9 @@ final class FormTest extends WebTestCase
     {
         $client = self::createClient();
 
-        $client->request('POST', '/not-holiday', ['not_holidays' => ['day' => '2020-01-02']]);
+        $client->request('POST', '/holiday', ['holidays' => ['not_holiday' => '2020-01-02', 'holiday' => '2020-01-01']]);
 
         $this->assertSame(200, $client->getResponse()->getStatusCode(), $client->getResponse()->getContent());
-        $this->assertSame('not-holiday', $client->getResponse()->getContent());
     }
 
     protected static function getKernelClass()

--- a/tests/Aeon/Symfony/AeonBundle/Tests/Functional/FormTest.php
+++ b/tests/Aeon/Symfony/AeonBundle/Tests/Functional/FormTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aeon\Symfony\AeonBundle\Tests\Functional;
+
+use Aeon\Symfony\AeonBundle\Tests\Functional\App\TestAppKernel;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class FormTest extends WebTestCase
+{
+    public function test_not_holiday_validator_for_holiday() : void
+    {
+        $client = self::createClient();
+
+        $client->request('POST', '/not-holiday', ['not_holidays' => ['day' => '2020-01-01']]);
+
+        $this->assertSame(422, $client->getResponse()->getStatusCode(), $client->getResponse()->getContent());
+        $this->assertStringContainsString('ERROR: Day "2020-01-01" is a holiday.', $client->getResponse()->getContent());
+    }
+
+    public function test_not_holiday_validator_for_not_holiday() : void
+    {
+        $client = self::createClient();
+
+        $client->request('POST', '/not-holiday', ['not_holidays' => ['day' => '2020-01-02']]);
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode(), $client->getResponse()->getContent());
+        $this->assertSame('not-holiday', $client->getResponse()->getContent());
+    }
+
+    protected static function getKernelClass()
+    {
+        return TestAppKernel::class;
+    }
+}

--- a/tests/Aeon/Symfony/AeonBundle/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Aeon/Symfony/AeonBundle/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Aeon\Symfony\AeonBundle\Tests\Unit\DependencyInjection;
 
+use Aeon\Calendar\Gregorian\Holidays\GoogleRegionalHolidaysFactory;
 use Aeon\Symfony\AeonBundle\DependencyInjection\Configuration;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Processor;
@@ -19,6 +20,7 @@ final class ConfigurationTest extends TestCase
         $this->assertEquals('Y-m-d H:i:s', $config['ui_datetime_format']);
         $this->assertEquals('Y-m-d', $config['ui_date_format']);
         $this->assertEquals('H:i:s', $config['ui_time_format']);
+        $this->assertEquals(GoogleRegionalHolidaysFactory::class, $config['calendar_holidays_factory_service']);
     }
 
     public function test_changed_configuration() : void

--- a/tests/Aeon/Symfony/AeonBundle/Tests/Unit/Validator/Constraints/AbstractComparisonValidatorTestCase.php
+++ b/tests/Aeon/Symfony/AeonBundle/Tests/Unit/Validator/Constraints/AbstractComparisonValidatorTestCase.php
@@ -7,7 +7,7 @@ namespace Aeon\Symfony\AeonBundle\Tests\Unit\Validator\Constraints;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
-abstract class AbstractConstraintValidatorTestCase extends ConstraintValidatorTestCase
+abstract class AbstractComparisonValidatorTestCase extends ConstraintValidatorTestCase
 {
     /**
      * @dataProvider provideValidComparisons

--- a/tests/Aeon/Symfony/AeonBundle/Tests/Unit/Validator/Constraints/AfterOrEqualValidatorTest.php
+++ b/tests/Aeon/Symfony/AeonBundle/Tests/Unit/Validator/Constraints/AfterOrEqualValidatorTest.php
@@ -11,7 +11,7 @@ use Aeon\Symfony\AeonBundle\Validator\Constraints\AfterOrEqualValidator;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
-final class AfterOrEqualValidatorTest extends AbstractConstraintValidatorTestCase
+final class AfterOrEqualValidatorTest extends AbstractComparisonValidatorTestCase
 {
     public function provideValidComparisons() : \Generator
     {

--- a/tests/Aeon/Symfony/AeonBundle/Tests/Unit/Validator/Constraints/AfterValidatorTest.php
+++ b/tests/Aeon/Symfony/AeonBundle/Tests/Unit/Validator/Constraints/AfterValidatorTest.php
@@ -11,7 +11,7 @@ use Aeon\Symfony\AeonBundle\Validator\Constraints\AfterValidator;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
-final class AfterValidatorTest extends AbstractConstraintValidatorTestCase
+final class AfterValidatorTest extends AbstractComparisonValidatorTestCase
 {
     public function provideValidComparisons() : \Generator
     {

--- a/tests/Aeon/Symfony/AeonBundle/Tests/Unit/Validator/Constraints/BeforeOrEqualValidatorTest.php
+++ b/tests/Aeon/Symfony/AeonBundle/Tests/Unit/Validator/Constraints/BeforeOrEqualValidatorTest.php
@@ -11,7 +11,7 @@ use Aeon\Symfony\AeonBundle\Validator\Constraints\BeforeOrEqualValidator;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
-final class BeforeOrEqualValidatorTest extends AbstractConstraintValidatorTestCase
+final class BeforeOrEqualValidatorTest extends AbstractComparisonValidatorTestCase
 {
     public function provideValidComparisons() : \Generator
     {

--- a/tests/Aeon/Symfony/AeonBundle/Tests/Unit/Validator/Constraints/BeforeValidatorTest.php
+++ b/tests/Aeon/Symfony/AeonBundle/Tests/Unit/Validator/Constraints/BeforeValidatorTest.php
@@ -11,7 +11,7 @@ use Aeon\Symfony\AeonBundle\Validator\Constraints\BeforeValidator;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
-final class BeforeValidatorTest extends AbstractConstraintValidatorTestCase
+final class BeforeValidatorTest extends AbstractComparisonValidatorTestCase
 {
     public function provideValidComparisons() : \Generator
     {

--- a/tests/Aeon/Symfony/AeonBundle/Tests/Unit/Validator/Constraints/EqualValidatorTest.php
+++ b/tests/Aeon/Symfony/AeonBundle/Tests/Unit/Validator/Constraints/EqualValidatorTest.php
@@ -11,7 +11,7 @@ use Aeon\Symfony\AeonBundle\Validator\Constraints\EqualValidator;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
-final class EqualValidatorTest extends AbstractConstraintValidatorTestCase
+final class EqualValidatorTest extends AbstractComparisonValidatorTestCase
 {
     public function provideValidComparisons() : \Generator
     {

--- a/tests/Aeon/Symfony/AeonBundle/Tests/Unit/Validator/Constraints/HolidayValidatorTest.php
+++ b/tests/Aeon/Symfony/AeonBundle/Tests/Unit/Validator/Constraints/HolidayValidatorTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aeon\Symfony\AeonBundle\Tests\Unit\Validator\Constraints;
+
+use Aeon\Calendar\Gregorian\Day;
+use Aeon\Calendar\Gregorian\Holidays\GoogleRegionalHolidaysFactory;
+use Aeon\Symfony\AeonBundle\Validator\Constraints\Holiday;
+use Aeon\Symfony\AeonBundle\Validator\Constraints\HolidayValidator;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+final class HolidayValidatorTest extends ConstraintValidatorTestCase
+{
+    public function test_null_is_valid() : void
+    {
+        $this->validator->validate(null, new Holiday(['countryCode' => 'PL']));
+
+        $this->assertNoViolation();
+    }
+
+    public function test_empty_string_is_valid() : void
+    {
+        $this->validator->validate('', new Holiday(['countryCode' => 'PL']));
+
+        $this->assertNoViolation();
+    }
+
+    public function test_invalid_date_string_is_not_valid() : void
+    {
+        $this->validator->validate('not_valid_date', new Holiday(['countryCode' => 'PL']));
+
+        $this->buildViolation('Day {{ day }} is not a holiday.')
+            ->setParameter('{{ day }}', '"not_valid_date"')
+            ->setCode(Holiday::NOT_HOLIDAY_DAY)
+            ->assertRaised();
+    }
+
+    public function test_that_valid_holiday_string_is_valid() : void
+    {
+        $this->validator->validate('2020-01-01', new Holiday(['countryCode' => 'PL']));
+
+        $this->assertNoViolation();
+    }
+
+    public function test_that_valid_non_holiday_string_is_not_valid() : void
+    {
+        $this->validator->validate('2020-01-02', new Holiday(['countryCode' => 'PL']));
+
+        $this->buildViolation('Day {{ day }} is not a holiday.')
+            ->setParameter('{{ day }}', '"2020-01-02"')
+            ->setCode(Holiday::NOT_HOLIDAY_DAY)
+            ->assertRaised();
+    }
+
+    public function test_that_valid_non_holiday_aeon_day_is_not_valid() : void
+    {
+        $this->validator->validate(Day::fromString('2020-01-02'), new Holiday(['countryCode' => 'PL']));
+
+        $this->buildViolation('Day {{ day }} is not a holiday.')
+            ->setParameter('{{ day }}', '"2020-01-02"')
+            ->setCode(Holiday::NOT_HOLIDAY_DAY)
+            ->assertRaised();
+    }
+
+    public function test_that_valid_non_holiday_datetime_interface_is_not_valid() : void
+    {
+        $this->validator->validate(new \DateTimeImmutable('2020-01-02'), new Holiday(['countryCode' => 'PL']));
+
+        $this->buildViolation('Day {{ day }} is not a holiday.')
+            ->setParameter('{{ day }}', '"2020-01-02"')
+            ->setCode(Holiday::NOT_HOLIDAY_DAY)
+            ->assertRaised();
+    }
+
+    public function test_that_valid_holiday_aeon_day_is_valid() : void
+    {
+        $this->validator->validate(Day::fromString('2020-01-01'), new Holiday(['countryCode' => 'PL']));
+
+        $this->assertNoViolation();
+    }
+
+    public function test_that_valid_holiday_datetime_interface_is_valid() : void
+    {
+        $this->validator->validate(new \DateTimeImmutable('2020-01-01'), new Holiday(['countryCode' => 'PL']));
+
+        $this->assertNoViolation();
+    }
+
+    protected function createValidator() : ConstraintValidator
+    {
+        return new HolidayValidator(new GoogleRegionalHolidaysFactory());
+    }
+}

--- a/tests/Aeon/Symfony/AeonBundle/Tests/Unit/Validator/Constraints/NotHolidayValidatorTest.php
+++ b/tests/Aeon/Symfony/AeonBundle/Tests/Unit/Validator/Constraints/NotHolidayValidatorTest.php
@@ -33,7 +33,7 @@ final class NotHolidayValidatorTest extends ConstraintValidatorTestCase
 
         $this->buildViolation('Day {{ day }} is a holiday.')
             ->setParameter('{{ day }}', '"not_valid_date"')
-            ->setCode(NotHoliday::NOT_HOLIDAY_DAY)
+            ->setCode(NotHoliday::HOLIDAY_DAY)
             ->assertRaised();
     }
 
@@ -43,7 +43,7 @@ final class NotHolidayValidatorTest extends ConstraintValidatorTestCase
 
         $this->buildViolation('Day {{ day }} is a holiday.')
             ->setParameter('{{ day }}', '"2020-01-01"')
-            ->setCode(NotHoliday::NOT_HOLIDAY_DAY)
+            ->setCode(NotHoliday::HOLIDAY_DAY)
             ->assertRaised();
     }
 

--- a/tests/Aeon/Symfony/AeonBundle/Tests/Unit/Validator/Constraints/NotHolidayValidatorTest.php
+++ b/tests/Aeon/Symfony/AeonBundle/Tests/Unit/Validator/Constraints/NotHolidayValidatorTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aeon\Symfony\AeonBundle\Tests\Unit\Validator\Constraints;
+
+use Aeon\Calendar\Gregorian\Day;
+use Aeon\Calendar\Gregorian\Holidays\GoogleRegionalHolidaysFactory;
+use Aeon\Symfony\AeonBundle\Validator\Constraints\NotHoliday;
+use Aeon\Symfony\AeonBundle\Validator\Constraints\NotHolidayValidator;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+final class NotHolidayValidatorTest extends ConstraintValidatorTestCase
+{
+    public function test_null_is_valid() : void
+    {
+        $this->validator->validate(null, new NotHoliday(['countryCode' => 'PL']));
+
+        $this->assertNoViolation();
+    }
+
+    public function test_empty_string_is_valid() : void
+    {
+        $this->validator->validate('', new NotHoliday(['countryCode' => 'PL']));
+
+        $this->assertNoViolation();
+    }
+
+    public function test_invalid_date_string_is_not_valid() : void
+    {
+        $this->validator->validate('not_valid_date', new NotHoliday(['countryCode' => 'PL']));
+
+        $this->buildViolation('Day {{ day }} is a holiday.')
+            ->setParameter('{{ day }}', '"not_valid_date"')
+            ->setCode(NotHoliday::NOT_HOLIDAY_DAY)
+            ->assertRaised();
+    }
+
+    public function test_that_valid_holiday_string_is_not_valid() : void
+    {
+        $this->validator->validate('2020-01-01', new NotHoliday(['countryCode' => 'PL']));
+
+        $this->buildViolation('Day {{ day }} is a holiday.')
+            ->setParameter('{{ day }}', '"2020-01-01"')
+            ->setCode(NotHoliday::NOT_HOLIDAY_DAY)
+            ->assertRaised();
+    }
+
+    public function test_that_valid_non_holiday_string_is_valid() : void
+    {
+        $this->validator->validate('2020-01-02', new NotHoliday(['countryCode' => 'PL']));
+
+        $this->assertNoViolation();
+    }
+
+    public function test_that_valid_non_holiday_aeon_day_is_valid() : void
+    {
+        $this->validator->validate(Day::fromString('2020-01-02'), new NotHoliday(['countryCode' => 'PL']));
+
+        $this->assertNoViolation();
+    }
+
+    public function test_that_valid_non_holiday_datetime_interface_is_valid() : void
+    {
+        $this->validator->validate(new \DateTimeImmutable('2020-01-02'), new NotHoliday(['countryCode' => 'PL']));
+
+        $this->assertNoViolation();
+    }
+
+    protected function createValidator() : ConstraintValidator
+    {
+        return new NotHolidayValidator(new GoogleRegionalHolidaysFactory());
+    }
+}


### PR DESCRIPTION
So basically adding NotHoliday constraint to any Date or DateTime form type would let us validate if given date is not a holiday. 

```php
final class SomeFormType extends AbstractType
{
    public function buildForm(FormBuilderInterface $builder, array $options) : void
    {
        $builder->add('day', AeonDayType::class, [
            'constraints' => [new NotHoliday(['countryCode' => 'US'])],
        ]);
    }
}
```

Constraint requires country the country code in which it will look for holidays at given date. 

Additionally if anyone would like to create own HolidaysProvider, it's possible by adding into the bundle configuration under following key id of the service that implements `HolidaysFactory` from `aeon-php/calendar-holidays` library.

Default: 
```yaml
aeon:
   calendar_holidays_factory_service: 'Aeon\Calendar\Gregorian\Holidays\GoogleRegionalHolidaysFactory'
```