### PR TITLE
Make tests less fragile by increasing limit reset and using EqualsWithDelta

### DIFF
--- a/tests/Aeon/Symfony/AeonBundle/Tests/Functional/App/TestAppKernel.php
+++ b/tests/Aeon/Symfony/AeonBundle/Tests/Functional/App/TestAppKernel.php
@@ -93,7 +93,7 @@ final class TestAppKernel extends BaseKernel
                     'algorithm' => 'sliding_window',
                     'configuration' => [
                         'limit' => 5,
-                        'time_window' => '1 second',
+                        'time_window' => '10 seconds',
                         'storage_service_id' => 'cache.psr.array',
                     ],
                 ],

--- a/tests/Aeon/Symfony/AeonBundle/Tests/Functional/ThrottleRequestTest.php
+++ b/tests/Aeon/Symfony/AeonBundle/Tests/Functional/ThrottleRequestTest.php
@@ -20,7 +20,7 @@ final class ThrottleRequestTest extends WebTestCase
 
         $this->assertSame(5, (int) $client->getResponse()->headers->get('x-ratelimit-limit'));
         $this->assertSame(4, (int) $client->getResponse()->headers->get('x-ratelimit-remaining'));
-        $this->assertSame(1, (int) $client->getResponse()->headers->get('x-ratelimit-reset'));
+        $this->assertEqualsWithDelta(10, (int) $client->getResponse()->headers->get('x-ratelimit-reset'), 2);
 
         $client->request('POST', '/throttle');
 
@@ -28,7 +28,7 @@ final class ThrottleRequestTest extends WebTestCase
 
         $this->assertSame(5, (int) $client->getResponse()->headers->get('x-ratelimit-limit'));
         $this->assertSame(3, (int) $client->getResponse()->headers->get('x-ratelimit-remaining'));
-        $this->assertSame(1, (int) $client->getResponse()->headers->get('x-ratelimit-reset'));
+        $this->assertEqualsWithDelta(10, (int) $client->getResponse()->headers->get('x-ratelimit-reset'), 2);
 
         $client->request('POST', '/throttle');
 
@@ -36,7 +36,7 @@ final class ThrottleRequestTest extends WebTestCase
 
         $this->assertSame(5, (int) $client->getResponse()->headers->get('x-ratelimit-limit'));
         $this->assertSame(2, (int) $client->getResponse()->headers->get('x-ratelimit-remaining'));
-        $this->assertSame(1, (int) $client->getResponse()->headers->get('x-ratelimit-reset'));
+        $this->assertEqualsWithDelta(10, (int) $client->getResponse()->headers->get('x-ratelimit-reset'), 2);
 
         $client->request('POST', '/throttle');
 
@@ -44,7 +44,7 @@ final class ThrottleRequestTest extends WebTestCase
 
         $this->assertSame(5, (int) $client->getResponse()->headers->get('x-ratelimit-limit'));
         $this->assertSame(1, (int) $client->getResponse()->headers->get('x-ratelimit-remaining'));
-        $this->assertSame(1, (int) $client->getResponse()->headers->get('x-ratelimit-reset'));
+        $this->assertEqualsWithDelta(10, (int) $client->getResponse()->headers->get('x-ratelimit-reset'), 2);
 
         $client->request('POST', '/throttle');
 
@@ -52,7 +52,7 @@ final class ThrottleRequestTest extends WebTestCase
 
         $this->assertSame(5, (int) $client->getResponse()->headers->get('x-ratelimit-limit'));
         $this->assertSame(0, (int) $client->getResponse()->headers->get('x-ratelimit-remaining'));
-        $this->assertSame(1, (int) $client->getResponse()->headers->get('x-ratelimit-reset'));
+        $this->assertEqualsWithDelta(10, (int) $client->getResponse()->headers->get('x-ratelimit-reset'), 2);
 
         $client->request('POST', '/throttle');
 
@@ -61,7 +61,7 @@ final class ThrottleRequestTest extends WebTestCase
 
         $this->assertSame(5, (int) $client->getResponse()->headers->get('x-ratelimit-limit'));
         $this->assertSame(0, (int) $client->getResponse()->headers->get('x-ratelimit-remaining'));
-        $this->assertSame(1, (int) $client->getResponse()->headers->get('x-ratelimit-reset'));
+        $this->assertEqualsWithDelta(10, (int) $client->getResponse()->headers->get('x-ratelimit-reset'), 2);
     }
 
     public function test_throttled_endpoint_with_not_throttled_method() : void
@@ -88,7 +88,7 @@ final class ThrottleRequestTest extends WebTestCase
 
         $this->assertSame(5, (int) $client->getResponse()->headers->get('x-ratelimit-limit'));
         $this->assertSame(0, (int) $client->getResponse()->headers->get('x-ratelimit-remaining'));
-        $this->assertSame(1, (int) $client->getResponse()->headers->get('x-ratelimit-reset'));
+        $this->assertEqualsWithDelta(10, (int) $client->getResponse()->headers->get('x-ratelimit-reset'), 2);
     }
 
     protected static function getKernelClass()


### PR DESCRIPTION
This will reduce random failures, initially, I thought it was sam nasty bug inside of the rate limiter component.

Rate Limiter test suite executed `./vendor/bin/phpunit --repeat 10000` did not failed even once. 

But then I realized it's actually related to the fact that sometimes tests are executed just between whole seconds. 

Adding delta would prevent situations when reset happened by a half-second too fast than expected.  

Expanding the time window to 10 seconds will help to avoid 429 response codes in tests that does not expect them. 