### PR TITLE
Fixed transformation when data provided as string to datetime form types

### DIFF
--- a/src/Aeon/Symfony/AeonBundle/Form/DataTransformer/AeonDateTimeToDateTimeTransformer.php
+++ b/src/Aeon/Symfony/AeonBundle/Form/DataTransformer/AeonDateTimeToDateTimeTransformer.php
@@ -19,6 +19,10 @@ final class AeonDateTimeToDateTimeTransformer implements DataTransformerInterfac
             return $value->toDateTimeImmutable();
         }
 
+        if (\is_string($value)) {
+            return new \DateTimeImmutable($value);
+        }
+
         return $value;
     }
 

--- a/src/Aeon/Symfony/AeonBundle/Form/DataTransformer/AeonDayToDateTimeTransformer.php
+++ b/src/Aeon/Symfony/AeonBundle/Form/DataTransformer/AeonDayToDateTimeTransformer.php
@@ -19,6 +19,10 @@ final class AeonDayToDateTimeTransformer implements DataTransformerInterface
             return $value->toDateTimeImmutable();
         }
 
+        if (\is_string($value)) {
+            return new \DateTimeImmutable($value);
+        }
+
         return $value;
     }
 

--- a/src/Aeon/Symfony/AeonBundle/Form/DataTransformer/AeonTimeToDateTimeTransformer.php
+++ b/src/Aeon/Symfony/AeonBundle/Form/DataTransformer/AeonTimeToDateTimeTransformer.php
@@ -20,6 +20,10 @@ final class AeonTimeToDateTimeTransformer implements DataTransformerInterface
             return new \DateTimeImmutable($value->toString());
         }
 
+        if (\is_string($value)) {
+            return new \DateTimeImmutable($value);
+        }
+
         return $value;
     }
 

--- a/tests/Aeon/Symfony/AeonBundle/Tests/Unit/Form/Type/AeonDateTimeTypeTest.php
+++ b/tests/Aeon/Symfony/AeonBundle/Tests/Unit/Form/Type/AeonDateTimeTypeTest.php
@@ -112,7 +112,20 @@ final class AeonDateTimeTypeTest extends TypeTestCase
         $this->assertNull($form->getData());
     }
 
-    protected function getTestedType()
+    public function test_submit_single_text_widget_with_not_empty_data_string() : void
+    {
+        $form = $this->factory->create(self::TESTED_TYPE, '2010-06-02 03:00:00 UTC', [
+            'widget' => 'single_text',
+        ]);
+
+        $form->submit('2010-06-02 03:04:00 UTC');
+
+        $dateTime = DateTime::fromString('2010-06-02 03:04:00 UTC');
+
+        $this->assertEquals($dateTime, $form->getData());
+    }
+
+    protected function getTestedType() : string
     {
         return self::TESTED_TYPE;
     }

--- a/tests/Aeon/Symfony/AeonBundle/Tests/Unit/Form/Type/AeonDayTimeTypeTest.php
+++ b/tests/Aeon/Symfony/AeonBundle/Tests/Unit/Form/Type/AeonDayTimeTypeTest.php
@@ -110,7 +110,20 @@ final class AeonDayTimeTypeTest extends TypeTestCase
         $this->assertNull($form->getData());
     }
 
-    protected function getTestedType()
+    public function test_submit_single_text_widget_with_non_empty_data() : void
+    {
+        $form = $this->factory->create(self::TESTED_TYPE, '2010-06-02', [
+            'widget' => 'single_text',
+        ]);
+
+        $form->submit('2010-06-02');
+
+        $dateTime = Day::fromString('2010-06-02');
+
+        $this->assertEquals($dateTime, $form->getData());
+    }
+
+    protected function getTestedType() : string
     {
         return self::TESTED_TYPE;
     }

--- a/tests/Aeon/Symfony/AeonBundle/Tests/Unit/Form/Type/AeonTimeTypeTest.php
+++ b/tests/Aeon/Symfony/AeonBundle/Tests/Unit/Form/Type/AeonTimeTypeTest.php
@@ -110,7 +110,20 @@ final class AeonTimeTypeTest extends TypeTestCase
         $this->assertNull($form->getData());
     }
 
-    protected function getTestedType()
+    public function test_submit_single_text_widget_with_non_empty_data() : void
+    {
+        $form = $this->factory->create(self::TESTED_TYPE, '13:00', [
+            'widget' => 'single_text',
+        ]);
+
+        $form->submit('13:00');
+
+        $dateTime = Time::fromString('13:00');
+
+        $this->assertEquals($dateTime, $form->getData());
+    }
+
+    protected function getTestedType() : string
     {
         return self::TESTED_TYPE;
     }

--- a/tests/Aeon/Symfony/AeonBundle/Tests/Unit/Form/Type/AeonTimeZoneTypeTest.php
+++ b/tests/Aeon/Symfony/AeonBundle/Tests/Unit/Form/Type/AeonTimeZoneTypeTest.php
@@ -69,7 +69,18 @@ final class AeonTimeZoneTypeTest extends TypeTestCase
         $this->assertNull($form->getData());
     }
 
-    protected function getTestedType()
+    public function test_submit_string_with_non_empty_data() : void
+    {
+        $form = $this->factory->create(self::TESTED_TYPE, 'Europe/Warsaw');
+
+        $form->submit('Europe/Warsaw');
+
+        $timeZone = TimeZone::europeWarsaw();
+
+        $this->assertEquals($timeZone, $form->getData());
+    }
+
+    protected function getTestedType() : string
     {
         return self::TESTED_TYPE;
     }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Transformers failing when data provided as a string</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a shore description of changes in this section, feel free to use markdown syntax -->
